### PR TITLE
Change bitcode-payment-protocol-dash reposition to kuvacash

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bip38": "^1.3.0",
     "bitcore-lib-dash": "^0.14.3",
     "bitcore-mnemonic-dash": "^1.2.3",
-    "bitcore-payment-protocol-dash": "github:dashpay/bitcore-payment-protocol-dash#master_v1.2.2",
+    "bitcore-payment-protocol-dash": "github:kuvacash/bitcore-payment-protocol-dash#master_v1.2.2",
     "json-stable-stringify": "^1.0.0",
     "lodash": "^3.3.1",
     "preconditions": "^1.0.8",


### PR DESCRIPTION
Update the repository URL to point to kuvacash for bitcode-payment-protocol-dash dependency.